### PR TITLE
remove session dependencie

### DIFF
--- a/src/components/OrderList/index.js
+++ b/src/components/OrderList/index.js
@@ -150,7 +150,7 @@ export const OrderList = (props) => {
         requestsState.orders.cancel()
       }
     }
-  }, [session])
+  }, [])
 
   useEffect(() => {
     if (orderList.loading) return


### PR DESCRIPTION
Session dependency in react-native apps call loadOrders so the pagination current increase. I tested in web removing session dependency and i didn't see issues.