### PR TITLE
📦: upgrade libphonenumber-js to version 1.11.19 and switch react-phon…

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dayjs": "^1.9.3",
     "decimal.js": "^10.4.3",
     "firebase": "9.15.0",
-    "libphonenumber-js": "^1.9.17",
+    "libphonenumber-js": "1.11.19",
     "moment": "^2.29.4",
     "ordering-api-sdk": "github:Ordering-Inc/ordering-api-sdk#release",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
…e-number-input to a Git repository source temporal solution